### PR TITLE
Update memory workflow docs for Codex

### DIFF
--- a/.claude/commands/pre-seed.md
+++ b/.claude/commands/pre-seed.md
@@ -1,1 +1,1 @@
-Reference @CLAUDE for specific instructions on how to interact with the codebase. See @README for project overview and @docs/ROADMAP for guidance and direction on this project. You are required to follow all rules in the memory workflow. Advise me when you are ready to begin working on a task.
+Reference @CLAUDE for specific instructions on how to interact with the codebase. See @README for project overview and @docs/ROADMAP for guidance and direction on this project. Codex should skip memory workflow steps. Advise me when you are ready to begin working on a task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ export PROXMOX_MCP_CONFIG="proxmox-config/config.json"
 - **@docs/development-workflow.md** - CI/CD and automation details
 
 ### AI Workflow Instructions
-- **@docs/ai-instructions/memory-instructions.md** - Memory management workflow
+- **@docs/ai-instructions/memory-instructions.md** - Memory management workflow *(mem0 server unavailable in Codex; ignore this workflow)*
 - **@docs/ai-instructions/context-instructions.md** - Context research workflow
 - **@docs/ai-instructions/github-instructions.md** - Git and GitHub best practices
 - **@docs/ai-instructions/issue-creation-instructions.md** - Creating well-structured issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 # Additional Instructions
-- memory workflow @/workspaces/ProxmoxMCP/docs/ai-instructions/memory-instructions.md
+- memory workflow @/workspaces/ProxmoxMCP/docs/ai-instructions/memory-instructions.md (not supported in Codex)
 - context workflow @/workspaces/ProxmoxMCP/docs/ai-instructions/context-instructions.md
 - github workflow @/workspaces/ProxmoxMCP/docs/ai-instructions/github-instructions.md
 - issue creation workflow @/workspaces/ProxmoxMCP/docs/ai-instructions/issue-creation-instructions.md

--- a/docs/ai-instructions/memory-instructions.md
+++ b/docs/ai-instructions/memory-instructions.md
@@ -1,5 +1,6 @@
 # docs
 
+> **Warning**: The mem0 server is not accessible in Codex. These instructions are informational only.
 
 The mem0 server provides three main tools for managing code preferences:
 


### PR DESCRIPTION
## Summary
- note that mem0 memory workflow isn't supported in Codex in AI workflow instructions
- warn about inaccessible mem0 server in memory instructions
- mark memory workflow link in CLAUDE.md as unsupported in Codex
- update pre-seed command to skip memory workflow steps

## Testing
- `pytest` *(fails: ModuleNotFoundError)*
- `black .`
- `mypy .` *(fails: found 39 errors)*
- `ruff check .` *(fails: found 42 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684160f83f688333ac29644893011d13