### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,5 +1,9 @@
 name: Auto-add to Project
 
+permissions:
+  contents: read
+  repository-projects: write
+
 on:
   issues:
     types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/basher83/ProxmoxMCP/security/code-scanning/3](https://github.com/basher83/ProxmoxMCP/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the functionality of the `actions/add-to-project` action, the workflow likely requires `contents: read` to access repository contents and `repository-projects: write` to modify the project. These permissions should be added at the workflow level to apply to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
