### PR TITLE
Remove deprecated dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 10
-    reviewers:
-      - "basher83"
     assignees:
       - "basher83"
     commit-message:
@@ -60,8 +58,6 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
-    reviewers:
-      - "basher83"
     assignees:
       - "basher83"
     commit-message:
@@ -80,8 +76,6 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
-    reviewers:
-      - "basher83"
     assignees:
       - "basher83"
     commit-message:


### PR DESCRIPTION
## Summary
- drop reviewers from `.github/dependabot.yml`

## Testing
- `pytest` *(fails: ModuleNotFoundError)*
- `black .`
- `mypy .` *(fails: missing imports)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6849ef06de748333b6b3a8295441e6c3