### PR TITLE
ci: ignore cache timeouts in autofix workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -38,6 +38,7 @@ jobs:
       # Cache UV virtual environment
       - name: Cache UV venv
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
@@ -80,6 +81,7 @@ jobs:
 
       - name: Cache UV venv
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
@@ -125,6 +127,7 @@ jobs:
       - name: Cache UV venv
         if: steps.check-tests.outputs.tests-exist == 'true'
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}


### PR DESCRIPTION
## Summary
- allow UV venv cache steps to fail without noisy errors

## Testing
- `pytest` *(fails: ModuleNotFoundError)*
- `black .`
- `mypy .` *(fails: found errors)*
- `ruff check .` *(fails: found errors)*

------
https://chatgpt.com/codex/tasks/task_e_684289f2b7848333b743a08085189300